### PR TITLE
ci: fix token-permissions code scanning findings

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -5,13 +5,13 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow updates to the repository
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   build:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build-validation-report.yaml
+++ b/.github/workflows/build-validation-report.yaml
@@ -4,12 +4,14 @@ on:
     workflows: ["build-validation"] # runs after build-validation workflow
     types:
       - completed
-permissions:
-  contents: read
-  actions: read
-  checks: write
+permissions: {}
+
 jobs:
   report:
+    permissions:
+      contents: read
+      actions: read
+      checks: write
     runs-on: ubuntu-latest
     steps:
       # fail-on-error is set to false so that PRs which don't touch the path-filtered

--- a/.github/workflows/build-validation.yaml
+++ b/.github/workflows/build-validation.yaml
@@ -11,9 +11,7 @@ on:
 permissions:
   contents: read
   actions: read
-  checks: write
-  pull-requests: write
-  statuses: write
+  pull-requests: read
 
 jobs:
   build-validation:

--- a/.github/workflows/publish-module-manualversionupdate.yaml
+++ b/.github/workflows/publish-module-manualversionupdate.yaml
@@ -4,23 +4,28 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
-  contents: write
-  checks: write
+  contents: read
   actions: read
-  pull-requests: write
-  statuses: write
 
 jobs:
   build-validation:
     uses: ./.github/workflows/build-validation.yaml
+    permissions:
+      contents: read
+      actions: read
 
   build-report:
     uses: ./.github/workflows/build-maester-report-template.yaml
+    permissions:
+      contents: read
+      actions: read
 
   create-release:
     needs: [build-validation, build-report]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish-module-manualversionupdate.yaml
+++ b/.github/workflows/publish-module-manualversionupdate.yaml
@@ -3,9 +3,7 @@ name: publish-module-post-manual-version-update
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  actions: read
+permissions: {}
 
 jobs:
   build-validation:

--- a/.github/workflows/publish-module-preview.yaml
+++ b/.github/workflows/publish-module-preview.yaml
@@ -11,20 +11,22 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
-  contents: write
-  checks: write
+  contents: read
   actions: read
-  pull-requests: write
-  statuses: write
 
 jobs:
   build-report:
     uses: ./.github/workflows/build-maester-report-template.yaml
+    permissions:
+      contents: read
+      actions: read
 
   create-preview-release:
     needs: build-report
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish-module-preview.yaml
+++ b/.github/workflows/publish-module-preview.yaml
@@ -10,9 +10,7 @@ on:
       - "report/**"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  actions: read
+permissions: {}
 
 jobs:
   build-report:

--- a/.github/workflows/publish-module.yaml
+++ b/.github/workflows/publish-module.yaml
@@ -4,23 +4,28 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
-  contents: write
-  checks: write
+  contents: read
   actions: read
-  pull-requests: write
-  statuses: write
 
 jobs:
   build-validation:
     uses: ./.github/workflows/build-validation.yaml
+    permissions:
+      contents: read
+      actions: read
 
   build-report:
     uses: ./.github/workflows/build-maester-report-template.yaml
+    permissions:
+      contents: read
+      actions: read
 
   create-release:
     needs: [build-validation, build-report]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish-module.yaml
+++ b/.github/workflows/publish-module.yaml
@@ -3,9 +3,7 @@ name: publish-module
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  actions: read
+permissions: {}
 
 jobs:
   build-validation:

--- a/.github/workflows/publish-versioned-docs.yml
+++ b/.github/workflows/publish-versioned-docs.yml
@@ -11,10 +11,7 @@ on:
     types: [published]
   workflow_dispatch:
 
-permissions:
-  contents: write
-  actions: read
-  pull-requests: read
+permissions: {}
 
 concurrency:
   group: docs-versioning-${{ github.event.release.tag_name }}
@@ -25,6 +22,9 @@ jobs:
     # This job only runs if a GitHub release was successfully published
     if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
 
     steps:
       - name: ⬇️ Checkout Repository

--- a/.github/workflows/update-module-docs.yaml
+++ b/.github/workflows/update-module-docs.yaml
@@ -9,13 +9,14 @@ on:
       - "!powershell/Maester.psd1"
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   update-command-reference:
     runs-on: windows-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/update-role-definitions.yaml
+++ b/.github/workflows/update-role-definitions.yaml
@@ -5,6 +5,8 @@ on:
     - cron: "0 8 1 * *" # Monthly on the 1st at 08:00 UTC
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
   group: update-role-definitions
   cancel-in-progress: false

--- a/.github/workflows/update-tag-documentation.yml
+++ b/.github/workflows/update-tag-documentation.yml
@@ -7,12 +7,13 @@ on:
       - 'build/Update-TagsDocumentation.ps1'
       - '.github/workflows/update-tags.yml'
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   update-tags:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

Addresses 17 of 18 OSSF Scorecard `Token-Permissions` alerts reported in GitHub Code Scanning by applying least-privilege principles to GitHub Actions workflow permissions.

## Changes

### Unnecessary permissions removed (8 alerts resolved)
These permissions were never used by any step — likely added historically but no longer needed:

| Workflow | Removed |
|----------|---------|
| `build-validation.yaml` | `checks:write`, `statuses:write`; downgraded `pull-requests:write` → `read` |
| `publish-module.yaml` | `checks:write`, `statuses:write`, `id-token:write`, `pull-requests:write` |
| `publish-module-preview.yaml` | Same as above |
| `publish-module-manualversionupdate.yaml` | Same as above |

### Top-level write permissions scoped to job level (9 alerts resolved)
Write permissions moved from workflow-level (all jobs) to the specific job that actually needs them. A `permissions: {}` deny-all block is added at the top level.

| Workflow | Alert | Fix |
|----------|-------|-----|
| `publish-module.yaml` | `contents:write` topLevel | Scoped to `create-release` job |
| `publish-module-preview.yaml` | `contents:write` topLevel | Scoped to `create-preview-release` job |
| `publish-module-manualversionupdate.yaml` | `contents:write` topLevel | Scoped to `create-release` job |
| `build-docs.yaml` | `contents:write` topLevel | Scoped to `build` job |
| `build-validation-report.yaml` | `checks:write` topLevel | Scoped to `report` job |
| `publish-versioned-docs.yml` | `contents:write` topLevel | Scoped to `version_and_deploy_docs` job |
| `update-module-docs.yaml` | `contents:write` topLevel | Scoped to `update-command-reference` job |
| `update-tag-documentation.yml` | `contents:write` topLevel | Scoped to `update-tags` job |
| `update-role-definitions.yaml` | Missing top-level block | Added `permissions: {}` |

## Remaining alert

**Alert 171** (`update-role-definitions.yaml` — jobLevel `contents:write`) should be **dismissed** via the Security tab with reason: "`contents:write` is required by `peter-evans/create-pull-request` to push a branch and create a PR — cannot be avoided without switching to a GitHub App or PAT."

## How code scanning will refresh

OSSF Scorecard runs on `push` to `main`, on schedule (Tuesdays 16:40 UTC), and on `branch_protection_rule` events. Once this PR is merged to `main`, the Scorecard workflow will re-scan automatically and close the resolved alerts. No manual intervention is needed.